### PR TITLE
feat: hide cancel button

### DIFF
--- a/lib/fields/KeywordsFilter.tsx
+++ b/lib/fields/KeywordsFilter.tsx
@@ -34,6 +34,7 @@ const KeywordsFilter: React.FC<FilterProps> = props => {
       loadOptions,
       i18n,
       showReset,
+      showCancel,
       defaultMatchType = 'all'
     } = {},
   } = (field.input || {}) as KeywordsInputProps;
@@ -221,15 +222,17 @@ const KeywordsFilter: React.FC<FilterProps> = props => {
           </div>
         )}
         <div className="wand__inline-filter__keywords__popover-footer-right">
-          <Button
-            type="link"
-            onClick={() => {
-              setInternalValue(value || defaultValue)
-              setPopoverIsOpen(false)
-            }}
-          >
-            { i18n?.cancelText || 'Cancel' }
-          </Button>
+          {showCancel && (
+            <Button
+              type="link"
+              onClick={() => {
+                setInternalValue(value || defaultValue)
+                setPopoverIsOpen(false)
+              }}
+            >
+              { i18n?.cancelText || 'Cancel' }
+            </Button>
+          )}
           <Button
             type="primary"
             disabled={internalValue?.keywords?.length === 0}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -84,6 +84,7 @@ export type KeywordsInputProps = {
   inputProps: {
     loadOptions: (props: KeywordsLoadOptionsProps) => Promise<string[]>;
     showReset?: boolean;
+    showCancel?: boolean;
     defaultMatchType?: string;
     i18n?: {
       matchText?: string;


### PR DESCRIPTION
Ajout d'une props pour cacher le bouton cancel du keywords filter

https://app.shortcut.com/9troisquartscom/story/27174/pb-affichage-filtre-mais-il-faut-supprimer-le-bouton-cancel-qui-au-final-ne-sert-pas