### PR TITLE
feat: Create exclude/include for keywords

### DIFF
--- a/lib/index.css
+++ b/lib/index.css
@@ -341,13 +341,16 @@
   display: flex;
   gap: 5px;
   align-items: center;
-  padding: 5px;
+  font-size: 14px;
 }
 
-.wand__inline-filter__keywords__popover__keyword:hover {
-  background-color: #adbebc;
-  border-radius: 8px;
-  transition: background-color 0.3s ease;
+.wand__inline-filter__keywords__popover__keyword__list {
+  padding-left: 20px;
+  margin-bottom: 0;
+}
+
+.wand__inline-filter__keywords__popover__match-type-radio {
+  margin-top: 8px;
 }
 
 .wand__inline-filter__options-group__title {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -78,8 +78,14 @@ export type BooleanInputProps = {
 };
 
 export type KeywordsLoadOptionsProps = {
-  keywords: string[]
-  matchType: string
+  include: {
+    keywords: string[];
+    matchType: string
+  },
+  exclude: {
+    keywords: string[];
+    matchType: string;
+  }
 };
 
 export type KeywordsInputProps = {
@@ -90,6 +96,8 @@ export type KeywordsInputProps = {
     showCancel?: boolean;
     defaultMatchType?: string;
     i18n?: {
+      includeText?: string;
+      excludeText?: string;
       matchText?: string;
       allText?: string;
       anyText?: string;


### PR DESCRIPTION
https://app.shortcut.com/9troisquartscom/story/28288/filtres-filtre-n%C3%A9gatif

Ajoute la possibilité d'exclure des mots clés dans le filtre keywords (NOT LIKE)
La structure de l'objet passe de 

{ keywords: [], matchType: 'all' } 
à 
{ include : { keywords: [], matchType: 'all' }, exclude: { keywords: [], matchType: 'all' }  }

On peut envoyer à la fois des keywords 'include' et 'exclude'