### PR TITLE
feat: Affichage du bouton de réinitialisation des filtres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.6.3](https://github.com/9troisquarts/inline-filters/compare/v2.6.2...v2.6.3) (2025-01-27)
+
+
+### Bug Fixes
+
+* change load options keywords structure ([0e4526d](https://github.com/9troisquarts/inline-filters/commit/0e4526dbee10ee0d3865a48d91ac75ef379571ea))
+
 ### [2.6.2](https://github.com/9troisquarts/inline-filters/compare/v2.6.1...v2.6.2) (2025-01-27)
 
 

--- a/lib/InlineFilters.tsx
+++ b/lib/InlineFilters.tsx
@@ -36,6 +36,7 @@ type BaseInlineFilters<T extends Record<string, any>> = {
   delay?: number;
   resetText?: string;
   debug?: boolean;
+  persistResetButton?: boolean;
   toggle?: FilterTogglerType;
   resetButton?: React.ReactNode;
   resetButtonProps?: ButtonProps;
@@ -63,6 +64,7 @@ const InlineFilters = <T extends Record<string, any>, >(props: InlineFiltersWith
     delay = 200,
     resetText,
     toggle,
+    persistResetButton = false,
     resetButton,
     resetButtonProps = {},
     onReset,
@@ -194,7 +196,7 @@ const InlineFilters = <T extends Record<string, any>, >(props: InlineFiltersWith
         {toggle && (toggle?.position !== "before") && (
           ToggleComponent
         )}
-        {onReset && (internalValue && objectIsPresent(internalValue)) && resetComponent}
+        {onReset && (persistResetButton || (internalValue && objectIsPresent(internalValue))) && resetComponent}
       </Space>
     </ConfigProvider>
   );

--- a/lib/InlineFilters.tsx
+++ b/lib/InlineFilters.tsx
@@ -36,10 +36,11 @@ type BaseInlineFilters<T extends Record<string, any>> = {
   delay?: number;
   resetText?: string;
   debug?: boolean;
-  persistResetButton?: boolean;
   toggle?: FilterTogglerType;
   resetButton?: React.ReactNode;
   resetButtonProps?: ButtonProps;
+  // Always show the reset button, never show it, or show it only when filters are set
+  resetButtonVisibility?: "always" | "never" | "dirty";
   onReset?: () => void;
   onChange: (object: T, value: T) => void;
 }
@@ -64,7 +65,7 @@ const InlineFilters = <T extends Record<string, any>, >(props: InlineFiltersWith
     delay = 200,
     resetText,
     toggle,
-    persistResetButton = false,
+    resetButtonVisibility = 'dirty',
     resetButton,
     resetButtonProps = {},
     onReset,
@@ -167,6 +168,9 @@ const InlineFilters = <T extends Record<string, any>, >(props: InlineFiltersWith
       {...(toggle || {})}
     />
   ) : undefined;
+
+  const showResetButton = onReset && (resetButtonVisibility === 'always' || (resetButtonVisibility == 'dirty' && internalValue && objectIsPresent(internalValue)));
+
   return (
     <ConfigProvider locale={antdLocaleForLocale[config.locale]}>
       <Space style={{ width: "100%" }} wrap>
@@ -196,7 +200,7 @@ const InlineFilters = <T extends Record<string, any>, >(props: InlineFiltersWith
         {toggle && (toggle?.position !== "before") && (
           ToggleComponent
         )}
-        {onReset && (persistResetButton || (internalValue && objectIsPresent(internalValue))) && resetComponent}
+        {showResetButton && resetComponent}
       </Space>
     </ConfigProvider>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@9troisquarts/inline-filters",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@9troisquarts/inline-filters",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "devDependencies": {
         "@ant-design/icons": "<5",
         "@faker-js/faker": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@9troisquarts/inline-filters",
   "private": false,
-  "version": "2.6.2",
+  "version": "2.6.3",
   "type": "module",
   "files": [
     "dist"


### PR DESCRIPTION
**Contexte :**

Actuellement le bouton Reset des inline-filters ne s'affiche pas quand aucune valeur n'est sélectionné dans les filtres donc quand l'objet search est vide, ce qui est logique

Sur Icare il m'est demandé de quand même afficher le bouton reset quand la search est vide

Donc j'ai ajouté une prop boolean `persistResetButton` qui va persister l'affichage du bouton reset même quand les filtres sont vides

La condition change ici :
`{onReset && (persistResetButton || (internalValue && objectIsPresent(internalValue))) && resetComponent}`

Donc ça reste le même comportement car la nouvelle prop est false par défaut


